### PR TITLE
Fix `USER`

### DIFF
--- a/inc/Client.hpp
+++ b/inc/Client.hpp
@@ -6,7 +6,7 @@
 /*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:29:30 by idelibal          #+#    #+#             */
-/*   Updated: 2024/12/05 18:28:01 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 15:17:33 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -26,6 +26,9 @@ class Client {
 		bool		hasProvidedPassword;
 		bool		hasNickname;
 		bool		hasUsername;
+		std::string	hostname;
+		std::string	servername;
+		std::string	realname;
 
 	public:
 		std::string	buffer;	// For incoming message buffering
@@ -42,6 +45,9 @@ class Client {
 		void	setHasProvidedPassword(bool status);
 		void	setHasNickname(bool status);
 		void	setHasUsername(bool status);
+		void	setHostname(const std::string& hostname);
+		void	setServername(const std::string& servername);
+		void	setRealname(const std::string& realname);
 
 		// Getters
 		int			getFd();
@@ -52,6 +58,9 @@ class Client {
 		bool 		getHasProvidedPassword();
 		bool		getHasNickname();
 		bool		getHasUsername();
+		const std::string& getHostname() const;
+		const std::string& getServername() const;
+		const std::string& getRealname() const;
 };
 
 #endif // CLIENT_HPP

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Client.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
+/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:32:00 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/06 15:20:44 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 18:37:10 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -58,7 +58,10 @@ void	Client::setHostname(const std::string& hostname) {
 }
 
 void	Client::setServername(const std::string& servername) {
-	this->servername = servername;
+	if (servername == "*")
+		this->servername = "MyIRC";
+	else
+		this->servername = servername;
 }
 
 void	Client::setRealname(const std::string& realname)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -6,7 +6,7 @@
 /*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:32:00 by idelibal          #+#    #+#             */
-/*   Updated: 2024/12/04 17:01:09 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 15:20:44 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,19 @@ void	Client::setHasUsername(bool status) {
 	hasUsername = status;
 }
 
+void	Client::setHostname(const std::string& hostname) {
+	this->hostname = hostname;
+}
+
+void	Client::setServername(const std::string& servername) {
+	this->servername = servername;
+}
+
+void	Client::setRealname(const std::string& realname)
+{
+	this->realname = realname;
+}
+
 // -----------------------------------Getters-----------------------------------
 int	Client::getFd() {
 	return fd;
@@ -81,3 +94,20 @@ bool	Client::getHasNickname() {
 bool	Client::getHasUsername() {
 	return hasUsername;
 }
+
+const std::string& Client::getHostname() const
+{
+	return hostname;
+}
+
+const std::string& Client::getServername() const
+{
+	return servername;	
+}
+
+
+const std::string& Client::getRealname() const
+{
+	return realname;
+}
+

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Commands.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
+/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/06 16:38:59 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 18:45:56 by mortins-         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -60,10 +60,6 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 		server.sendError(client->getFd(), "451", "USER :You must provide PASS first");
 		return;
 	}
-	// if (!client->getHasNickname()) {
-	// 	server.sendError(client->getFd(), "451", "USER :You must set a NICK first");
-	// 	return;
-	// }
 	if (params.empty()) {
 		server.sendError(client->getFd(), "461", "USER :Not enough parameters");
 		return;
@@ -73,6 +69,10 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 	std::string			username, hostname, servername, realname;
 	iss >> username >> hostname >> servername;
 	std::getline(iss, realname);
+
+	for (size_t i = 0; i < realname.size() && realname[i] == ' '; i++) {
+		realname.erase(0, 1);
+	}
 
 	if (!realname.empty() && realname[0] == ':')
 		realname.erase(0, 1);

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -6,7 +6,7 @@
 /*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/06 15:23:37 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 15:26:24 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,7 +74,7 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 	if (!realname.empty() && realname[0] == ':')
 		realname.erase(0, 1);
 
-	if (username.empty()) {
+	if (username.empty() || hostname.empty() || servername.empty() || realname.empty()) {
 		server.sendError(client->getFd(), "461", "USER :Not enough parameters");
 		return;
 	}

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -6,7 +6,7 @@
 /*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/06 15:26:24 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 16:38:59 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,10 @@ void	handleNickCommand(Server& server, Client* client, const std::string& nickna
 
 	client->setNickname(nickname);
 	client->setHasNickname(true);
-	server.sendNotice(client->getFd(), "Nickname set. Please provide your USER details.");
+	if (client->getAuthenticationStatus() && client->getHasUsername())
+		server.sendWelcomeMessage(client);
+	else
+		server.sendNotice(client->getFd(), "Nickname set. Please set your USER.");
 }
 
 void	handleUserCommand(Server& server, Client* client, const std::string& params) {
@@ -57,10 +60,10 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 		server.sendError(client->getFd(), "451", "USER :You must provide PASS first");
 		return;
 	}
-	if (!client->getHasNickname()) {
-		server.sendError(client->getFd(), "451", "USER :You must set a NICK first");
-		return;
-	}
+	// if (!client->getHasNickname()) {
+	// 	server.sendError(client->getFd(), "451", "USER :You must set a NICK first");
+	// 	return;
+	// }
 	if (params.empty()) {
 		server.sendError(client->getFd(), "461", "USER :Not enough parameters");
 		return;
@@ -85,8 +88,10 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 	client->setRealname(realname);
 	client->setHasUsername(true);
 
-	if (client->getAuthenticationStatus() && !client->getNickname().empty())
+	if (client->getAuthenticationStatus() && client->getHasNickname())
 		server.sendWelcomeMessage(client);
+	else
+		server.sendNotice(client->getFd(), "USER set. Please set your NICK.");
 }
 
 void handleJoinCommand(Server& server, Client* client, const std::string& params) {

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -6,7 +6,7 @@
 /*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/06 14:50:26 by idelibal         ###   ########.fr       */
+/*   Updated: 2025/01/06 15:23:37 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -80,6 +80,9 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 	}
 
 	client->setUsername(username);
+	client->setHostname(hostname);
+	client->setServername(servername);
+	client->setRealname(realname);
 	client->setHasUsername(true);
 
 	if (client->getAuthenticationStatus() && !client->getNickname().empty())

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Commands.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
+/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/03 18:05:26 by mortins-         ###   ########.fr       */
+/*   Updated: 2025/01/06 14:17:59 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,32 +33,9 @@ void	handlePassCommand(Server& server, Client* client, const std::string& pass) 
 	}
 }
 
-void	handleNickCommand(Server& server, Client* client, const std::string& nickname) {
-	if (!client->getHasProvidedPassword()) {
-		server.sendError(client->getFd(), "451", "NICK :You must provide PASS first");
-		return;
-	}
-	if (nickname.empty()) {
-		server.sendError(client->getFd(), "431", "NICK :No nickname given");
-		return;
-	}
-	if (!server.isNicknameUnique(nickname)) {
-		server.sendError(client->getFd(), "433", nickname + " :Nickname is already in use");
-		return;
-	}
-
-	client->setNickname(nickname);
-	client->setHasNickname(true);
-	server.sendNotice(client->getFd(), "Nickname set. Please provide your USER details.");
-}
-
 void	handleUserCommand(Server& server, Client* client, const std::string& params) {
 	if (!client->getHasProvidedPassword()) {
 		server.sendError(client->getFd(), "451", "USER :You must provide PASS first");
-		return;
-	}
-	if (!client->getHasNickname()) {
-		server.sendError(client->getFd(), "451", "USER :You must set a NICK first");
 		return;
 	}
 	if (params.empty()) {
@@ -81,10 +58,34 @@ void	handleUserCommand(Server& server, Client* client, const std::string& params
 
 	client->setUsername(username);
 	client->setHasUsername(true);
+	server.sendNotice(client->getFd(), "USER set. Please provide your NICK details.");
+}
+
+void	handleNickCommand(Server& server, Client* client, const std::string& nickname) {
+	if (!client->getHasProvidedPassword()) {
+		server.sendError(client->getFd(), "451", "NICK :You must provide PASS first");
+		return;
+	}
+	if (!client->getHasUsername()) {
+		server.sendError(client->getFd(), "451", "NICK :You must set a USER first");
+		return;
+	}
+	if (nickname.empty()) {
+		server.sendError(client->getFd(), "431", "NICK :No nickname given");
+		return;
+	}
+	if (!server.isNicknameUnique(nickname)) {
+		server.sendError(client->getFd(), "433", nickname + " :Nickname is already in use");
+		return;
+	}
+
+	client->setNickname(nickname);
+	client->setHasNickname(true);
 
 	if (client->getAuthenticationStatus() && !client->getNickname().empty())
 		server.sendWelcomeMessage(client);
 }
+
 
 void handleJoinCommand(Server& server, Client* client, const std::string& params) {
 	std::istringstream iss(params);


### PR DESCRIPTION
@mortinso Removed the order for `USER` and `NICK`. Now only the `PASS` must be first. Also left the possibility that the client can specify the name of the server, since you say that it is needed for the `LIST`. But I couldn't replicate the error for `LIST` in HexChat. When I write the command List, just a new window with a list of channels opens and no errors.

Please deal with this bug since you found it and previously created the `LIST` command. 