### PR TITLE
fix: Actually delete channels when all users leave

### DIFF
--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Channel.cpp                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
+/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:26:51 by idelibal          #+#    #+#             */
-/*   Updated: 2024/12/30 18:49:01 by mortins-         ###   ########.fr       */
+/*   Updated: 2025/01/08 20:55:53 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -39,9 +39,6 @@ void	Channel::removeMember(Client* client) {
 			it++;
 		addOperator(it->second);
 	}
-
-	if (members.size() == 1)
-		std::cout << "Channel " << name << " deleted" << std::endl;
 	members.erase(client->getFd());
 }
 

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Commands.cpp                                       :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
+/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:33:21 by idelibal          #+#    #+#             */
-/*   Updated: 2025/01/08 18:05:47 by mortins-         ###   ########.fr       */
+/*   Updated: 2025/01/08 20:51:58 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -208,7 +208,7 @@ void	handleQuitCommand(Server& server, Client* client, const std::string& messag
 
 	// Notify all channels and remove the client
 	for (std::map<std::string, Channel*>::iterator it = server.getChannels().begin();
-		it != server.getChannels().end(); ++it) {
+		it != server.getChannels().end();) {
 		Channel* channel = it->second;
 		if (channel->isMember(client))
 		{
@@ -217,7 +217,16 @@ void	handleQuitCommand(Server& server, Client* client, const std::string& messag
 
 			// Remove the quitting client from the channel
 			channel->removeMember(client);
+
+			if (channel->getMemberCount() == 0)
+			{
+				std::string chanName = it->first;
+				++it;
+				server.deleteChannel(chanName);
+				continue;
+			}
 		}
+		++it;
 	}
 
 	// Notify the client

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Server.cpp                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mortins- <mortins-@student.42lisboa.com    +#+  +:+       +#+        */
+/*   By: idelibal <idelibal@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/11/25 17:39:59 by idelibal          #+#    #+#             */
-/*   Updated: 2024/12/30 19:22:43 by mortins-         ###   ########.fr       */
+/*   Updated: 2025/01/08 20:56:10 by idelibal         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -114,7 +114,7 @@ void	Server::receiveNewData(int fd) {
 	if (bytes <= 0) {
 		std::string quitMsg = ":" + getClientByFd(fd)->getNickname() + ": Client disconnected\r\n";
 		for (std::map<std::string, Channel*>::iterator it = getChannels().begin();
-			it != getChannels().end(); ++it) {
+			it != getChannels().end();) {
 			Channel* channel = it->second;
 			if (channel->isMember(getClientByFd(fd)))
 			{
@@ -123,7 +123,16 @@ void	Server::receiveNewData(int fd) {
 
 				// Remove the quitting client from the channel
 				channel->removeMember(getClientByFd(fd));
+
+				if (channel->getMemberCount() == 0)
+				{
+					std::string chanName = it->first;
+					++it;
+					deleteChannel(chanName);
+					continue;
+				}
 			}
+			++it;
 		}
 
 		// Notify the client
@@ -281,9 +290,14 @@ void	Server::signalHandler(int signum) {
 }
 
 void	Server::deleteChannel(const std::string& channelName) {
-	Channel*	channel = channels[channelName];
-	delete channel; // Free the memory for the channel
-	channels.erase(channelName); // Remove the channel from the map
+	std::map<std::string, Channel*>::iterator it = channels.find(channelName);
+	if (it != channels.end()) {
+		std::string name = it->first;
+		Channel* ch = it->second;
+		channels.erase(it); // Remove the channel from the map	
+		delete ch; // Free the memory allocated for the Channel object
+		std::cout << "Channel " << channelName << " deleted." << std::endl;
+	}
 }
 
 void	Server::closeFds() {


### PR DESCRIPTION
Checked in NС, the channel is now deleted. In HexChat, until we close the window, chats don't disappear from the menu, but I guess that's a HexChat specificity. The main thing is that they are removed from the channel list. 